### PR TITLE
Generate carrier version strings

### DIFF
--- a/carriersettings_extractor.py
+++ b/carriersettings_extractor.py
@@ -177,6 +177,7 @@ with open('apns-full-conf.xml', 'w', encoding='utf-8') as f:
     f.write('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n\n')
     f.write('<apns version="8">\n\n')
 
+    version_suffix = all_settings['default'].version % 1000000000
     for entry in carrier_list.entry:
         setting = all_settings[entry.canonicalName]
         for apn in setting.apns.apn:
@@ -198,6 +199,19 @@ with open('apns-full-conf.xml', 'w', encoding='utf-8') as f:
                     field,
                     getattr(entry.carrierId, field),
                 )
+
+        # Add version key composed of canonical name and versions
+        carrier_config_subelement = ET.SubElement(
+            carrier_config_element,
+            'string'
+        )
+        carrier_config_subelement.set('name', 'carrier_config_version_string')
+        carrier_config_subelement.text = '{}-{}.{}'.format(
+            setting.canonicalName,
+            setting.version,
+            version_suffix
+        )
+
         for config in setting.configs.config:
             value_type = config.WhichOneof('value')
             if value_type == 'textValue':


### PR DESCRIPTION
This generates version strings in the same format as stock CarrierSettings (e.g. tmobile_us-21000000082.26) to display in Settings for diagnostic purposes.