### PR TITLE
Exclude some values from vendor.xml

### DIFF
--- a/carriersettings_extractor.py
+++ b/carriersettings_extractor.py
@@ -14,6 +14,16 @@ from vendor.carrierId_pb2 import CarrierList as CarrierIdList
 
 pb_path = sys.argv[1]
 
+# Anything where the value is a package name
+unwanted_configs = ["carrier_app_wake_signal_config",
+                    "carrier_settings_activity_component_name_string",
+                    "carrier_setup_app_string",
+                    "config_ims_package_override_string",
+                    "enable_apps_string_array",
+                    "gps.nfw_proxy_apps",
+                    "smart_forwarding_config_component_name_string",
+                    "wfc_emergency_address_carrier_app_string"]
+
 carrier_id_list = CarrierIdList()
 carrier_attribute_map = {}
 with open('carrier_list.pb', 'rb') as pb:
@@ -213,6 +223,8 @@ with open('apns-full-conf.xml', 'w', encoding='utf-8') as f:
         )
 
         for config in setting.configs.config:
+            if config.key in unwanted_configs:
+                continue
             value_type = config.WhichOneof('value')
             if value_type == 'textValue':
                 carrier_config_subelement = ET.SubElement(


### PR DESCRIPTION
* This will make it work with the naked config
* We can have two different XMLs if needed, where one
  could include this config
* Looked for any 'com.google.android.' or Sprint/Verizon
  packages and removed those

Change-Id: I3d68c995f855c13231946a5796091936479906e9