### PR TITLE
Revert "Add support for legacy APV devices"

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -89,35 +89,3 @@ prebuilt_etc {
     product_specific: true,
     src: ":carrier_extraction-cc",
 }
-
-genrule {
-    name: "carrier_extraction-apn-apv",
-    tools: ["carriersettings_extractor"],
-    cmd: "$(location carriersettings_extractor) vendor/google_devices/$$TARGET_PRODUCT/product/etc/CarrierSettings/ . $(genDir)/apns-conf.xml $(genDir)/carrierconfig-vendor.xml $$TARGET_PRODUCT",
-    out: [
-        "apns-conf.xml",
-    ],
-}
-
-genrule {
-    name: "carrier_extraction-cc-apv",
-    tools: ["carriersettings_extractor"],
-    cmd: "$(location carriersettings_extractor) vendor/google_devices/$$TARGET_PRODUCT/product/etc/CarrierSettings/ . $(genDir)/apns-conf.xml $(genDir)/carrierconfig-vendor.xml $$TARGET_PRODUCT",
-    out: [
-        "carrierconfig-vendor.xml",
-    ],
-}
-
-prebuilt_etc {
-    name: "extracted-apns-apv",
-    filename: "apns-conf.xml",
-    product_specific: true,
-    src: ":carrier_extraction-apn-apv",
-}
-
-prebuilt_etc {
-    name: "extracted-carrierconfig-apv",
-    filename: "carrierconfig-vendor.xml",
-    product_specific: true,
-    src: ":carrier_extraction-cc-apv",
-}


### PR DESCRIPTION
This reverts commit 49b185426c128f3518902e9b723251d674a0e23a.