### PR TITLE
don't use carrier provided values of VoWiFi being available to toggle

### DIFF
--- a/carriersettings_extractor.py
+++ b/carriersettings_extractor.py
@@ -208,7 +208,9 @@ unwanted_configs = ["carrier_app_wake_signal_config",
                     "config_ims_rcs_package_override_string",
                     "editable_enhanced_4g_lte_bool",
                     "hide_enhanced_4g_lte_bool",
-                    "vonr_setting_visibility_bool"]
+                    "vonr_setting_visibility_bool",
+                    "editable_wfc_mode_bool",
+                    "editable_wfc_roaming_mode_bool"]
 
 unwanted_configs_6thgen = ["smart_forwarding_config_component_name_string"]
 


### PR DESCRIPTION
includes roaming and non-roaming

similar to VoLTE and VoNR changes where a carrier can choose to prevent a user from modifying this setting

depends on https://github.com/GrapheneOS/platform_frameworks_base/pull/349 for the roaming part, otherwise the user will never be able to change VoWiFi in roaming