### PR TITLE
ignore carriers (only Google Fi atm) requiring their app

### DIFF
--- a/carriersettings_extractor.py
+++ b/carriersettings_extractor.py
@@ -227,6 +227,7 @@ unwanted_configs = [
     "vonr_setting_visibility_bool",
     "editable_wfc_mode_bool",
     "editable_wfc_roaming_mode_bool",
+    "carrier_app_required_during_setup_bool",
 ]
 
 unwanted_configs_6thgen = ["smart_forwarding_config_component_name_string"]


### PR DESCRIPTION
Google Fi is the only carrier that requires this based on diff'ing before and after. It's possible removing this can make Google Fi work (or at least partially) without the app, and inherently without sandboxed Google Play, instead of it completely not working out the box. 

Needs testing from someone with Google Fi