### PR TITLE
add Soong logic for generating carrier settings

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -37,7 +37,7 @@ python_library_host {
 genrule {
     name: "carrier_extraction-apn",
     tools: ["carriersettings_extractor"],
-    cmd: "$(location carriersettings_extractor) vendor/google_devices/$$TARGET_PRODUCT/proprietary/product/etc/CarrierSettings/ . $(genDir)/apns-conf.xml $(genDir)/carrierconfig-vendor.xml $$TARGET_PRODUCT",
+    cmd: "$(location) --pb_files vendor/google_devices/$$TARGET_PRODUCT/proprietary/product/etc/CarrierSettings/*.pb --apn_out $(out)",
     out: [
         "apns-conf.xml",
     ],
@@ -46,7 +46,7 @@ genrule {
 genrule {
     name: "carrier_extraction-cc",
     tools: ["carriersettings_extractor"],
-    cmd: "$(location carriersettings_extractor) vendor/google_devices/$$TARGET_PRODUCT/proprietary/product/etc/CarrierSettings/ . $(genDir)/apns-conf.xml $(genDir)/carrierconfig-vendor.xml $$TARGET_PRODUCT",
+    cmd: "$(location) --pb_files vendor/google_devices/$$TARGET_PRODUCT/proprietary/product/etc/CarrierSettings/*.pb --cc_out $(out)",
     out: [
         "carrierconfig-vendor.xml",
     ],

--- a/Android.bp
+++ b/Android.bp
@@ -1,6 +1,19 @@
 soong_namespace {
 }
 
+bootstrap_go_package {
+    name: "soong-carrier_settings",
+    pkgPath: "android/soong/carrier_settings",
+    deps: [
+        "soong-android",
+        "soong-genrule",
+    ],
+    srcs: [
+        "build/carrier_settings.go",
+    ],
+    pluginFor: ["soong_build"],
+}
+
 python_binary_host {
     name: "carriersettings_extractor",
     defaults: ["carrier_extractor_defaults"],
@@ -34,19 +47,24 @@ python_library_host {
     },
 }
 
-genrule {
-    name: "carrier_extraction-apn",
+carrier_settings_genrule_defaults {
+    name: "carrier_settings_defaults",
     tools: ["carriersettings_extractor"],
-    cmd: "$(location) --pb_files vendor/google_devices/$$TARGET_PRODUCT/proprietary/product/etc/CarrierSettings/*.pb --apn_out $(out)",
+}
+
+genrule {
+    name: "apns_config",
+    defaults: ["carrier_settings_defaults"],
+    cmd: "$(location) --pb_files $(in) --apn_out $(out)",
     out: [
         "apns-conf.xml",
     ],
 }
 
 genrule {
-    name: "carrier_extraction-cc",
-    tools: ["carriersettings_extractor"],
-    cmd: "$(location) --pb_files vendor/google_devices/$$TARGET_PRODUCT/proprietary/product/etc/CarrierSettings/*.pb --cc_out $(out)",
+    name: "carrier_config",
+    defaults: ["carrier_settings_defaults"],
+    cmd: "$(location) --pb_files $(in) --cc_out $(out)",
     out: [
         "carrierconfig-vendor.xml",
     ],
@@ -56,12 +74,12 @@ prebuilt_etc {
     name: "extracted-apns",
     filename: "apns-conf.xml",
     product_specific: true,
-    src: ":carrier_extraction-apn",
+    src: ":apns_config",
 }
 
 prebuilt_etc {
     name: "extracted-carrierconfig",
     filename: "carrierconfig-vendor.xml",
     product_specific: true,
-    src: ":carrier_extraction-cc",
+    src: ":carrier_config",
 }

--- a/build/carrier_settings.go
+++ b/build/carrier_settings.go
@@ -1,0 +1,30 @@
+package carrier_settings
+
+import (
+	"path"
+
+	"android/soong/android"
+	"android/soong/genrule"
+)
+
+func carrierSettingsGenRuleDefaults(ctx android.LoadHookContext) {
+	type props struct {
+		Srcs []string
+	}
+
+	p := &props{}
+	p.Srcs = []string{path.Join("google_devices", ctx.Config().DeviceName(), "proprietary/product/etc/CarrierSettings/*.pb")}
+
+	ctx.AppendProperties(p)
+}
+
+func init() {
+	android.RegisterModuleType("carrier_settings_genrule_defaults", carrierSettingsGenRuleDefaultsFactory)
+}
+
+func carrierSettingsGenRuleDefaultsFactory() android.Module {
+	module := genrule.DefaultsFactory()
+	android.AddLoadHook(module, carrierSettingsGenRuleDefaults)
+
+	return module
+}

--- a/google_devices
+++ b/google_devices
@@ -1,0 +1,1 @@
+../google_devices


### PR DESCRIPTION
This adds a plugin for Soong to generate carrier settings. And fixes a bug with incremental builds, where carrier settings is not regenerated when product name is changed.